### PR TITLE
speakers: css fixes (long names break the layout)

### DIFF
--- a/src/render/styles/speakers.scss
+++ b/src/render/styles/speakers.scss
@@ -28,10 +28,11 @@
 .speaker {
 	float: left;
 	width: 33%;
+  	min-width: 325px; 
 	padding-right: 20px;
 	margin-bottom: 20px;
 	box-sizing: border-box;
-	min-height: 160px;
+	min-height: 175px;
 
 	h3 {
 		font-weight: bold;
@@ -77,7 +78,7 @@
 		position: relative;
 		background: $blue;
 		float: left;
-		margin-right: 24px;
+		margin-right: 8px;
 
 		&:before,
 		&:after {


### PR DESCRIPTION
This is a quick fix, may need additional work (for example the 8px margin may not be enugh from the design point of view). The min-width was needed for smaller screens (between 986 and 769).
